### PR TITLE
Remove malindented and incorrect reference to GCP

### DIFF
--- a/config/package/manifests/app.yaml
+++ b/config/package/manifests/app.yaml
@@ -10,7 +10,6 @@ overview: |-
 readme: |
   The no-op provider provides a single managed resource that becomes available
   as soon as it is created. It may be used to test composition.
- `provider-nop` is a Crossplane infrastructure provider for the [Google Cloud Platform](https://cloud.google.com).
 
 # Maintainer names and emails.
 maintainers:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

This line was indented too far, causing the package to fail. It also referenced GCP, which is not what this provider is.